### PR TITLE
Be more specific with dependencies - drop dependency on `rails`

### DIFF
--- a/cache_with_locale.gemspec
+++ b/cache_with_locale.gemspec
@@ -16,7 +16,9 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "rails"
+  s.add_dependency "railties"
+  s.add_dependency "activesupport"
+  s.add_dependency "actionview"
 
   s.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
This PR drops dependency for `rails` and instead specifies dependencies on the actual parts of Rails that the project is dependent on following best practices.

The advantage here is that this gem can be used in projects that does not include the whole `rails` gem, but rather use parts of Rails.